### PR TITLE
Feat/defer audio pre-caching until after page render

### DIFF
--- a/hello-firebase-react/src/components/AudioPlayer.tsx
+++ b/hello-firebase-react/src/components/AudioPlayer.tsx
@@ -121,17 +121,25 @@ const AudioPlayer = ({ projectId, onBack, setStickyPlayer }: AudioPlayerProps) =
         if (result.data.versions.length > 0) {
           setSelectedVersion(result.data.versions[0].filename);
         }
-        await preCacheVersions(result.data.versions);
+        setLoading(false);
       } catch (err) {
         console.error('Error loading project:', err);
         setError('Failed to load project. Please try again.');
-      } finally {
         setLoading(false);
       }
     };
 
     loadProject();
-  }, [projectId, preCacheVersions]);
+  }, [projectId]);
+
+  // Separate effect for pre-caching audio after initial render
+  useEffect(() => {
+    if (project && !loading) {
+      preCacheVersions(project.versions).catch(err => {
+        console.error('Error pre-caching versions:', err);
+      });
+    }
+  }, [project, loading, preCacheVersions]);
 
   const loadAudio = useCallback(async (filename: string): Promise<AudioBuffer> => {
     if (!audioContext.current) {


### PR DESCRIPTION
This PR makes the project view (AudioPlayer component) UX better by implementing the following changes:

- Only load audio file metadata for page rendering
- Defer audio pre-caching until after the page has been rendered (`useEffect` depending on `loading` state)
- Show a spinner in place of the play button during pre-caching

The AudioPlayer component loads faster because only audio metadata is initially loaded for the player and the rendering can begin before the audio has been pre-cached.